### PR TITLE
Included the method 'scrollToElementWhenVisible'

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ The above method waits for the URL not to contain an expected string. Such metho
 
 The above method fills an input field with a text as soon as such field is visible and then it simulates pressing the ENTER key from the keyboard. This method can receives four arguments: 1st - the text input HTML element (this is mandatory); 2nd - a string (the text you want to fill the input field with - this is mandatory); 3rd - an error message (this is optional and if not provided a default message implemented for this specific method will be displayed instead); 4th - a timeout (optional and default is 5000 milliseconds. Message turns mandatory if you need to change the default timeout, due to arguments order). This method is useful in cases such as when doing a search and pressing the ENTER key, instead of having to fill the input field and clicking the search button, for example.
 
+- `scrollToElementWhenVisible`
+
+The above method is used to scroll up to an element on the page as soon as the element is visible in the DOM. This method can receives three arguments: 1st - the HTML element (this is mandatory); 2nd - an error message (this is optional and if not provided a default message implemented for this specific method will be displayed instead); 3rd - a timeout (optional and default is 5000 milliseconds. Message turns mandatory if you need to change the default timeout, due to arguments order).
+
 ## How to use (examples)
 
 After installing the library you will need to require it in your test file (see below).
@@ -552,6 +556,24 @@ describe("foo", () => {
 });
 ```
 
+### Example of usage of `scrollToElementWhenVisible`
+
+```js
+const protractorHelper = require("protractor-helper");
+
+describe("foo", () => {
+    it("bar", () => {
+        browser.get("https://example.com");
+
+        const myLink = element(by.css("a.my-link"));
+
+        protractorHelper.scrollToElementWhenVisible(myLink, "my link is not visible", 3000);
+
+        // ...
+    });
+});
+```
+
 Note: All the examples are using ES6 syntax.
 
 ## Using methods that start with 'wait' as test expectations (or test assertions)
@@ -617,8 +639,8 @@ Started
 
 
 
-20 specs, 0 failures
-Finished in 2.501 seconds
+21 specs, 0 failures
+Finished in 2.968 seconds
 
 [23:28:40] I/local - Shutting down selenium standalone server.
 [23:28:40] I/launcher - 0 instance(s) of WebDriver still running

--- a/index.js
+++ b/index.js
@@ -24,6 +24,20 @@ function getDefaultIsNotVisibleMessage(htmlElement) {
   }' ${IS_NOT_VISIBLE_MESSAGE}`;
 }
 
+function getDefaultIsNotClickableMessage(htmlElement) {
+  return `${ELEMENT_WITH_LOCATOR_MESSAGE} '${
+    htmlElement.parentElementArrayFinder.locator_.value
+  }' ${IS_NOT_CLICKABLE_MESSAGE}. ${POSSIBLE_IT_IS_NOT_PRESENT_OR_VISIBLE_MESSAGE}`
+}
+
+function waitForElementToBeClickable (
+  htmlElement,
+  message = getDefaultIsNotClickableMessage(htmlElement),
+  timeout = DEFAULT_TIMEOUT_IN_MS
+) {
+  browser.wait(EC.elementToBeClickable(htmlElement), timeout, message);
+}
+
 const getBodyElementFromCurrentBrowserOrBrowserInstance = function(
   browserInstance
 ) {
@@ -84,12 +98,10 @@ const waitForElementNotToBeVisible = function(
 
 const clickWhenClickable = function(
   htmlElement,
-  message = `${ELEMENT_WITH_LOCATOR_MESSAGE} '${
-    htmlElement.parentElementArrayFinder.locator_.value
-  }' ${IS_NOT_CLICKABLE_MESSAGE}. ${POSSIBLE_IT_IS_NOT_PRESENT_OR_VISIBLE_MESSAGE}`,
+  message = getDefaultIsNotClickableMessage(htmlElement),
   timeout = DEFAULT_TIMEOUT_IN_MS
 ) {
-  browser.wait(EC.elementToBeClickable(htmlElement), timeout, message);
+  waitForElementToBeClickable(htmlElement, message, timeout);
   htmlElement.click();
 };
 
@@ -140,7 +152,7 @@ const tapWhenTappable = function(
   }' ${IS_NOT_TAPPABLE_MESSAGE}. ${POSSIBLE_IT_IS_NOT_PRESENT_OR_VISIBLE_MESSAGE}`,
   timeout = DEFAULT_TIMEOUT_IN_MS
 ) {
-  browser.wait(EC.elementToBeClickable(htmlElement), timeout, message);
+  waitForElementToBeClickable(htmlElement, message, timeout);
   browser
     .touchActions()
     .tap(htmlElement)
@@ -224,6 +236,15 @@ const fillFieldWithTextWhenVisibleAndPressEnter = function(
   );
 };
 
+const scrollToElementWhenVisible = function(
+  htmlElement,
+  message = getDefaultIsNotVisibleMessage(htmlElement),
+  timeout = DEFAULT_TIMEOUT_IN_MS
+) {
+  this.waitForElementVisibility(htmlElement, message, timeout);
+  browser.executeScript('arguments[0].scrollIntoView(true);', htmlElement);
+};
+
 module.exports = {
   getBodyElementFromCurrentBrowserOrBrowserInstance,
   openNewBrowserInTheSamePage,
@@ -244,5 +265,6 @@ module.exports = {
   waitForUrlNotToBeEqualToExpectedUrl,
   waitForUrlToContainString,
   waitForUrlNotToContainString,
-  fillFieldWithTextWhenVisibleAndPressEnter
+  fillFieldWithTextWhenVisibleAndPressEnter,
+  scrollToElementWhenVisible
 };

--- a/test/sample.spec.js
+++ b/test/sample.spec.js
@@ -118,4 +118,9 @@ describe("Protractor helper", () => {
       constants.SAMPLE_URL
     );
   });
+
+  it("scrollToElementWhenVisible", () => {
+    protractorHelper.scrollToElementWhenVisible(shortenButton);
+  });
+
 });


### PR DESCRIPTION
 I add the method `scrollToElementWhenVisible`, used to scroll up to an element on the page as soon as the element is visible in the DOM.

 Add the function `getDefaultIsNotClickableMessage` to centralize a default error message.

 Update the README and Sample.spec.