### PR TITLE
Include deprecated warn on some functions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: ""
+assignees: ""
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,15 +24,17 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: ""
+assignees: ""
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
 ## Pull Request Checklist
-	
-	- [ ] Have you followed the steps in our [Contributing](https://github.com/wlsf82/protractor-helper/blob/master/docs/CONTRIBUTING.md) document?
-	- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wlsf82/protractor-helper/pulls) for the same update/change?
-	- [ ] Have you successfully ran tests with your changes locally?
-	- [ ] Have you written new tests for your changes, if necessary?
-	- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-	- [ ] Have you made improvements to the documentation, if necessary? ([docs/](https://github.com/wlsf82/protractor-helper/tree/master/docs) folder and [README.md](https://github.com/wlsf82/protractor-helper/blob/master/README.md))
-	- [ ] Have you linked the correct [GitHub issue](https://github.com/wlsf82/protractor-helper/issues), if there is any?
-	
-	> Pull requests that do not pass the automated tests on [SemaphoreCI](http://semaphoreci.com) and the code quality verification on [Better Code Hub](https://bettercodehub.com/) will not be reviewed
+
+    - [ ] Have you followed the steps in our [Contributing](https://github.com/wlsf82/protractor-helper/blob/master/docs/CONTRIBUTING.md) document?
+    - [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wlsf82/protractor-helper/pulls) for the same update/change?
+    - [ ] Have you successfully ran tests with your changes locally?
+    - [ ] Have you written new tests for your changes, if necessary?
+    - [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
+    - [ ] Have you made improvements to the documentation, if necessary? ([docs/](https://github.com/wlsf82/protractor-helper/tree/master/docs) folder and [README.md](https://github.com/wlsf82/protractor-helper/blob/master/README.md))
+    - [ ] Have you linked the correct [GitHub issue](https://github.com/wlsf82/protractor-helper/issues), if there is any?
+
+    > Pull requests that do not pass the automated tests on [SemaphoreCI](http://semaphoreci.com) and the code quality verification on [Better Code Hub](https://bettercodehub.com/) will not be reviewed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+# 3.7.8
+
+## Deprecation
+
+- Started the deprecation of all functions below:
+
+  - getBodyElementFromCurrentBrowserOrBrowserInstance
+  - openNewBrowserInTheSamePage
+  - clickWhenClickable
+  - fillFieldWithTextWhenVisible
+  - fillInputFieldWithFileWhenPresent
+  - clearFieldWhenVisible
+  - clearFieldWhenVisibleAndFillItWithText
+  - tapWhenTappable
+  - fillFieldWithTextWhenVisibleAndPressEnter
+  - scrollToElementWhenVisible
+
+  In that patch we added a warning on console with information about what functions will be deprecated and a URL to the documentation about.
+  They will be deprecated on version 4.0.0
+
+  > Note: On all old functions the `errorMessage` argument isn't more necessary.
+
+## JavaScript files
+
+- Refactored some lines ocurring more 1 time.
+
 # 3.7.7
 
 ## package.json

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -14,22 +14,22 @@ appearance, race, religion, or sexual identity and orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
- advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
- address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
- professional setting
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
 
 ## Our Responsibilities
 

--- a/README.md
+++ b/README.md
@@ -18,24 +18,24 @@ Many of the helper functions on this library uses `protractor.ExpectedConditions
   <details><p><summary>Open to see all available helpers</summary>
 
   - [`setTimeout`](#settimeout)
-  - [`getBodyElementFromCurrentBrowserOrBrowserInstance`](#getbodyelementfromcurrentbrowserorbrowserinstance)
-  - [`openNewBrowserInTheSamePage`](#opennewbrowserinthesamepage)
+  - [`getBodyElementFromCurrentBrowserOrBrowserInstance`](#getbodyelementfromcurrentbrowserorbrowserinstance) **- Will be deprecated in version 4.0.0**
+  - [`openNewBrowserInTheSamePage`](#opennewbrowserinthesamepage) **- Will be deprecated in version 4.0.0**
   - [`isCurrentUrlDifferentFromBaseUrl`](#iscurrenturldifferentfrombaseurl)
   - [`waitForElementPresence`](#waitforelementpresence)
   - [`waitForElementNotToBePresent`](#waitforelementnottobepresent)
   - [`waitForElementVisibility`](#waitforelementvisibility)
   - [`waitForElementNotToBeVisible`](#waitforelementnottobevisible)
-  - [`clickWhenClickable`](#clickwhenclickable)
+  - [`clickWhenClickable`](#clickwhenclickable) **- Will be deprecated in version 4.0.0**
   - [`click`](#click)
-  - [`fillFieldWithTextWhenVisible`](#fillfieldwithtextwhenvisible)
+  - [`fillFieldWithTextWhenVisible`](#fillfieldwithtextwhenvisible) **- Will be deprecated in version 4.0.0**
   - [`fillFieldWithText`](#fillfieldwithtext)
-  - [`fillInputFieldWithFileWhenPresent`](#fillinputfieldwithfilewhenpresent)
+  - [`fillInputFieldWithFileWhenPresent`](#fillinputfieldwithfilewhenpresent) **- Will be deprecated in version 4.0.0**
   - [`uploadFileIntoInputField`](#uploadfileintoinputfield)
-  - [`clearFieldWhenVisible`](#clearfieldwhenvisible)
+  - [`clearFieldWhenVisible`](#clearfieldwhenvisible) **- Will be deprecated in version 4.0.0**
   - [`clear`](#clear)
-  - [`clearFieldWhenVisibleAndFillItWithText`](#clearfieldwhenvisibleandfillitwithtext)
+  - [`clearFieldWhenVisibleAndFillItWithText`](#clearfieldwhenvisibleandfillitwithtext) **- Will be deprecated in version 4.0.0**
   - [`clearFieldAndFillItWithText`](#clearfieldandfillitwithtext)
-  - [`tapWhenTappable`](#tapwhentappable)
+  - [`tapWhenTappable`](#tapwhentappable) **- Will be deprecated in version 4.0.0**
   - [`tap`](#tap)
   - [`waitForTextToBePresentInElement`](#waitfortexttobepresentinelement)
   - [`waitForTextNotToBePresentInElement`](#waitfortextnottobepresentinelement)
@@ -43,9 +43,9 @@ Many of the helper functions on this library uses `protractor.ExpectedConditions
   - [`waitForUrlNotToBeEqualToExpectedUrl`](#waitforurlnottobeequaltoexpectedurl)
   - [`waitForUrlToContainString`](#waitforurltocontainstring)
   - [`waitForUrlNotToContainString`](#waitforurlnottocontainstring)
-  - [`fillFieldWithTextWhenVisibleAndPressEnter`](#fillfieldwithtextwhenvisibleandpressenter)
+  - [`fillFieldWithTextWhenVisibleAndPressEnter`](#fillfieldwithtextwhenvisibleandpressenter) **- Will be deprecated in version 4.0.0**
   - [`fillFieldWithTextAndPressEnter`](#fillfieldwithtextandpressenter)
-  - [`scrollToElementWhenVisible`](#scrolltoelementwhenvisible)
+  - [`scrollToElementWhenVisible`](#scrolltoelementwhenvisible) **- Will be deprecated in version 4.0.0**
   - [`scrollToElement`](#scrolltoelement)
 
 </p> </details>
@@ -54,6 +54,7 @@ Many of the helper functions on this library uses `protractor.ExpectedConditions
 
   - [Example of a test failure when using such methods as expectations](#example-of-a-test-failure-when-using-such-methods-as-expectations)
 
+- [Deprecations on version 4.0.0](#deprecations-on-version-400)
 - [Contributing](#contributing)
 - [Credits](#credits)
 - [License](/LICENSE)
@@ -161,10 +162,14 @@ If called without passing an argument the timeout will be set to the default one
 
 ### `getBodyElementFromCurrentBrowserOrBrowserInstance`
 
+> **Will be removed in version 4.0.0, read more [here](#deprecations-on-version-400).**
+
 This method returns the body element of the current browser if nothing is passed as argument or the body element of a specific browser instance in case the browser instance is passed as an argument. This second option is useful when working with two browsers interacting with each other, for example.
 [Example](docs/EXAMPLES.md#getbodyelementfromcurrentbrowserorbrowserinstance)
 
 ### `openNewBrowserInTheSamePage`
+
+> **Will be removed in version 4.0.0, read more [here](#deprecations-on-version-400).**
 
 This method opens a new browser instance in the same page of the main browser.
 
@@ -202,10 +207,10 @@ This method is the opposite of the previous one, so, it waits for an element not
 
 ### `clickWhenClickable`
 
+> **Will be deprecated in version 4.0.0, please use the new ['click'](#click) function instead! Read more [here](#deprecations-on-version-400).**
+
 This method is used to click in an element as soon as it is in a clickable state. This means that the element is visible and enabled for clicking.
 [Example](docs/EXAMPLES.md#clickwhenclickable)
-
-> Note: this function will be deprecated in favor of the function `click`.
 
 ### `click`
 
@@ -214,10 +219,10 @@ This method is used to click in an element as soon as it is in a clickable state
 
 ### `fillFieldWithTextWhenVisible`
 
+> **Will be deprecated in version 4.0.0, please use the new ['fillFieldWithText'](#fillFieldWithText) function instead! Read more [here](#deprecations-on-version-400).**
+
 This method fills an input field with a text as soon as such field is visible.
 [Example](docs/EXAMPLES.md#fillfieldwithtextwhenvisible)
-
-> Note: this function will be deprecated in favor of the function `fillFieldWithText`.
 
 ### `fillFieldWithText`
 
@@ -226,10 +231,10 @@ This method fills an input field with a text as soon as such field is visible.
 
 ### `fillInputFieldWithFileWhenPresent`
 
+> **Will be deprecated in version 4.0.0, please use the new ['uploadFileIntoInputField'](#uploadFileIntoInputField) function instead! Read more [here](#deprecations-on-version-400).**
+
 This method fills a file input field with a specified file as soon as the file input field is present in the DOM.
 [Example](docs/EXAMPLES.md#fillinputfieldwithfilewhenpresent)
-
-> Note: this function will be deprecated in favor of the function `uploadFileIntoInputField`.
 
 ### `uploadFileIntoInputField`
 
@@ -238,10 +243,10 @@ This method uploads a file in a file input field as soon as the file input field
 
 ### `clearFieldWhenVisible`
 
+> **Will be deprecated in version 4.0.0, please use the new ['clear'](#clear) function instead! Read more [here](#deprecations-on-version-400).**
+
 This method clears a text input field as soon as such field is visible.
 [Example](docs/EXAMPLES.md#clearFieldWhenVisible)
-
-> Note: this function will be deprecated in favor of the function `clear`.
 
 ### `clear`
 
@@ -250,10 +255,10 @@ This method clears a text input field as soon as such field is visible.
 
 ### `clearFieldWhenVisibleAndFillItWithText`
 
+> **Will be deprecated in version 4.0.0, please use the new ['clearFieldAndFillItWithText'](#clearFieldAndFillItWithText) function instead! Read more [here](#deprecations-on-version-400).**
+
 This method clears a text input field as soon as such field is visible, and then it fills it with a text.
 [Example](docs/EXAMPLES.md#clearfieldwhenvisibleandfillitwithtext)
-
-> Note: this function will be deprecated in favor of the function `clearFieldAndFillItWithText`.
 
 ### `clearFieldAndFillItWithText`
 
@@ -262,10 +267,10 @@ This method clears a text input field as soon as such field is visible, and then
 
 ### `tapWhenTappable`
 
+> **Will be deprecated in version 4.0.0, please use the new ['tap'](#tap) function instead! Read more [here](#deprecations-on-version-400).**
+
 This method performs a tap action on a clickable/tappable HTML element as soon as it is in a clickable/tappable state. This method is used when performing web mobile testing in mobile emulators, for example.
 [Example](docs/EXAMPLES.md#tapwhentappable)
-
-> Note: this function will be deprecated in favor of the function `tap`.
 
 ### `tap`
 
@@ -304,10 +309,10 @@ This method waits for the URL not to contain an expected string. Such method is 
 
 ### `fillFieldWithTextWhenVisibleAndPressEnter`
 
+> **Will be deprecated in version 4.0.0, please use the new ['fillFieldWithTextAndPressEnter'](#fillFieldWithTextAndPressEnter) function instead! Read more [here](#deprecations-on-version-400).**
+
 This method fills an input field with a text as soon as such field is visible and then it simulates pressing the ENTER key from the keyboard. This method is useful in cases such as when doing a search and pressing the ENTER key, instead of having to fill the input field and clicking the search button, for example.
 [Example](docs/EXAMPLES.md#fillfieldwithtextwhenvisibleandpressenter)
-
-> Note: this function will be deprecated in favor of the function `fillFieldWithTextAndPressEnter`.
 
 ### `fillFieldWithTextAndPressEnter`
 
@@ -316,10 +321,10 @@ This method fills an input field with a text as soon as such field is visible an
 
 ### `scrollToElementWhenVisible`
 
+> **Will be deprecated in version 4.0.0, please use the new ['scrollToElement'](#scrollToElement) function instead! Read more [here](#deprecations-on-version-400).**
+
 This method is used to scroll up to an element on the page as soon as the element is visible in the DOM.
 [Example](docs/EXAMPLES.md#scrolltoelementwhenvisible)
-
-> Note: this function will be deprecated in favor of the function `scrollToElement`.
 
 ### `scrollToElement`
 
@@ -370,6 +375,30 @@ Failed: text 'foo' not present on element with locator 'By(css selector, h1)'.
 ```
 
 > As you can see, the messages are clear and tell you exactly why the test has failed, such as in the previous example, where a specific text ('foo') is not present in a heading element (an element with css selector 'h1').
+
+## Deprecations on version 4.0.0
+
+Ten functions will be removed or deprecated soon.
+
+- The 2 below will be removed for the library focus only on providing an easy way for software engineers to create robust end-to-end tests.
+
+  - [getBodyElementFromCurrentBrowserOrBrowserInstance](#getBodyElementFromCurrentBrowserOrBrowserInstance)
+  - [openNewBrowserInTheSamePage](#openNewBrowserInTheSamePage)
+
+- The 8 below will be deprecated to reduce complexity, with the new functions with less arguments and smaller name. Change the function on **Old** column to the matching function of **New** column.
+
+  > Note: All new methods don't use the `errorMessage` argument, remove it.
+
+  | Old (Before v4.0.0)                                                                     | New (Since v4.0.0)                                                |
+  | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+  | [clickWhenClickable](#clickWhenClickable)                                               | [click](#click)                                                   |
+  | [fillFieldWithTextWhenVisible](#fillFieldWithTextWhenVisible)                           | [fillFieldWithText](#fillFieldWithText)                           |
+  | [fillInputFieldWithFileWhenPresent](#fillInputFieldWithFileWhenPresent)                 | [uploadFileIntoInputField](#uploadFileIntoInputField)             |
+  | [clearFieldWhenVisible](#clearFieldWhenVisible)                                         | [clear](#clear)                                                   |
+  | [clearFieldWhenVisibleAndFillItWithText](#clearFieldWhenVisibleAndFillItWithText)       | [clearFieldAndFillItWithText](#clearFieldAndFillItWithText)       |
+  | [tapWhenTappable](#tapWhenTappable)                                                     | [tap](#tap)                                                       |
+  | [fillFieldWithTextWhenVisibleAndPressEnter](#fillFieldWithTextWhenVisibleAndPressEnter) | [fillFieldWithTextAndPressEnter](#fillFieldWithTextAndPressEnter) |
+  | [scrollToElementWhenVisible](#scrollToElementWhenVisible)                               | [scrollToElement](#scrollToElement)                               |
 
 ## Contributing
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -44,6 +44,8 @@ describe("foo", () => {
 
 ## getBodyElementFromCurrentBrowserOrBrowserInstance
 
+> Note: This function will be removed in version 4.0.0.
+
 ```js
 const protractorHelper = require("protractor-helper");
 
@@ -59,6 +61,8 @@ describe("foo", () => {
 ```
 
 ## openNewBrowserInTheSamePage
+
+> Note: This function will be removed in version 4.0.0.
 
 | 1 mandatory argument |
 | :------------------: |
@@ -198,7 +202,7 @@ describe("foo", () => {
 
 ## clickWhenClickable
 
-> Note: this function will be deprecated in favor of the function `click`.
+> Note: This function will be deprecated in version 4.0.0 in favor of the function [`click`](#click).
 
 | 1 mandatory argument |            2 optional arguments            |
 | :------------------: | :----------------------------------------: |
@@ -222,9 +226,9 @@ describe("foo", () => {
 
 ## click
 
-| 1 mandatory argument |   1 optional argument    |
-| :------------------: | :----------------------: |
-|    `htmlElement`     | `timeoutInMilliseconds`` |
+| 1 mandatory argument |   1 optional argument   |
+| :------------------: | :---------------------: |
+|    `htmlElement`     | `timeoutInMilliseconds` |
 
 ```js
 const protractorHelper = require("protractor-helper");
@@ -244,7 +248,7 @@ describe("foo", () => {
 
 ## fillFieldWithTextWhenVisible
 
-> Note: this function will be deprecated in favor of the function `fillFieldWithText`.
+> Note: This function will be deprecated in version 4.0.0 in favor of the function [`fillFieldWithText`](#fillFieldWithText).
 
 |  2 mandatory arguments   |            2 optional arguments            |
 | :----------------------: | :----------------------------------------: |
@@ -290,7 +294,7 @@ describe("foo", () => {
 
 ## fillInputFieldWithFileWhenPresent
 
-> Note: this function will be deprecated in favor of the function `uploadFileIntoInputField`.
+> Note: This function will be deprecated in version 4.0.0 in favor of the function ['uploadFileIntoInputField'](#uploadFileIntoInputField).
 
 |      2 mandatory arguments       |            2 optional arguments            |
 | :------------------------------: | :----------------------------------------: |
@@ -349,7 +353,7 @@ describe("foo", () => {
 
 ## clearFieldWhenVisible
 
-> Note: this function will be deprecated in favor of the function `clear`.
+> Note: This function will be deprecated in version 4.0.0 in favor of the function [`clear`](#clear).
 
 | 1 mandatory argument |            2 optional arguments            |
 | :------------------: | :----------------------------------------: |
@@ -397,7 +401,7 @@ describe("foo", () => {
 
 ## clearFieldWhenVisibleAndFillItWithText
 
-> Note: this function will be deprecated in favor of the function `clearFieldAndFillItWithText`.
+> Note: This function will be deprecated in version 4.0.0 in favor of the function [`clearFieldAndFillItWithText`](#clearFieldAndFillItWithText).
 
 |  2 mandatory arguments   |            2 optional arguments            |
 | :----------------------: | :----------------------------------------: |
@@ -443,7 +447,7 @@ describe("foo", () => {
 
 ## tapWhenTappable
 
-> Note: this function will be deprecated in favor of the function `tap`.
+> Note: This function will be deprecated in version 4.0.0 in favor of the function [`tap`](#tap).
 
 | 1 mandatory argument |            2 optional arguments            |
 | :------------------: | :----------------------------------------: |
@@ -645,7 +649,7 @@ describe("foo", () => {
 
 ## fillFieldWithTextWhenVisibleAndPressEnter
 
-> Note: this function will be deprecated in favor of the function `fillFieldWithTextAndPressEnter`.
+> Note: This function will be deprecated in version 4.0.0 in favor of the function [`fillFieldWithTextAndPressEnter`](#fillFieldWithTextAndPressEnter).
 
 |  2 mandatory arguments   |            2 optional arguments            |
 | :----------------------: | :----------------------------------------: |
@@ -696,7 +700,7 @@ describe("foo", () => {
 
 ## scrollToElementWhenVisible
 
-> Note: this function will be deprecated in favor of the function `scrollToElement`.
+> Note: This function will be deprecated in version 4.0.0 in favor of the function [`scrollToElement`](#scrollToElement).
 
 | 1 mandatory argument |            2 optional arguments            |
 | :------------------: | :----------------------------------------: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-helper",
-  "version": "3.7.7",
+  "version": "3.7.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@types/q": {
       "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
+      "resolved": "http://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
       "integrity": "sha1-vShOV8hPEyXacCur/IKlMoGQwMU=",
       "dev": true
     },
@@ -166,7 +166,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -176,6 +176,11 @@
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
       }
+    },
+    "colors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
     },
     "combined-stream": {
       "version": "1.0.7",
@@ -238,7 +243,7 @@
     },
     "core-js": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
       "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU=",
       "dev": true
     },
@@ -316,7 +321,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
@@ -615,7 +620,7 @@
       "dependencies": {
         "es6-promise": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+          "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
           "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
           "dev": true
         }
@@ -666,7 +671,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
@@ -709,7 +714,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         }
@@ -753,7 +758,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -1024,13 +1029,13 @@
     },
     "string_decoder": {
       "version": "0.10.31",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -1166,7 +1171,7 @@
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-helper",
-  "version": "3.7.7",
+  "version": "3.7.8",
   "scripts": {
     "pretest": "webdriver-manager update --gecko false",
     "test": "protractor test/protractor.conf.js",

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "pre-commit": "^1.2.2",
     "prettier": "1.15.2",
     "protractor": "^5.4.2"
+  },
+  "dependencies": {
+    "colors": "^1.3.3"
   }
 }

--- a/src/clickersAndTappers.js
+++ b/src/clickersAndTappers.js
@@ -6,8 +6,8 @@ const clickWhenClickable = function(
   timeoutInMilliseconds = utils.timeout.timeoutInMilliseconds,
   errorMessage = messageBuilder.getDefaultIsNotClickableMessage(htmlElement)
 ) {
-  utils.waitForElementToBeClickable(htmlElement, timeoutInMilliseconds, errorMessage);
-  htmlElement.click();
+  utils.replaceObsoleteFunction("clickWhenClickable", "click");
+  this.click(htmlElement, timeoutInMilliseconds);
 };
 
 const click = function(
@@ -27,11 +27,8 @@ const tapWhenTappable = function(
   timeoutInMilliseconds = utils.timeout.timeoutInMilliseconds,
   errorMessage = messageBuilder.getDefaultIsNotTappableMessage(htmlElement)
 ) {
-  utils.waitForElementToBeClickable(htmlElement, timeoutInMilliseconds, errorMessage);
-  browser
-    .touchActions()
-    .tap(htmlElement)
-    .perform();
+  utils.replaceObsoleteFunction("tapWhenTappable", "tap");
+  this.tap(htmlElement, timeoutInMilliseconds);
 };
 
 const tap = function(

--- a/src/constants_and_utils/utils.js
+++ b/src/constants_and_utils/utils.js
@@ -1,3 +1,5 @@
+const colors = require("colors");
+
 const timeoutInMilliseconds = require("./constants").DEFAULT_TIMEOUT_IN_MS;
 
 const EC = protractor.ExpectedConditions;
@@ -17,7 +19,24 @@ function waitForElementToBeClickable(htmlElement, timeoutInMilliseconds, errorMe
   browser.wait(EC.elementToBeClickable(htmlElement), timeoutInMilliseconds, errorMessage);
 }
 
+function obsoleteFunction(functionName, text = "") {
+  console.warn(
+    colors.yellow("Protractor-helper warning:") +
+      " Function '" +
+      functionName +
+      "' will be deprecated in version 4.0.0! " +
+      text +
+      colors.cyan("[Read more on www.npmjs.com/package/protractor-helper#deprecations-on-version-400]")
+  );
+}
+
+function replaceObsoleteFunction(oldFunctionName, newFunctionName) {
+  obsoleteFunction(oldFunctionName, "Please use the new '" + newFunctionName + "' function instead! ");
+}
+
 module.exports = {
+  obsoleteFunction,
+  replaceObsoleteFunction,
   requiredParam,
   timeout,
   waitForElementToBeClickable

--- a/src/inputFieldInteractions.js
+++ b/src/inputFieldInteractions.js
@@ -8,8 +8,8 @@ const fillFieldWithTextWhenVisible = function(
   timeoutInMilliseconds = utils.timeout.timeoutInMilliseconds,
   errorMessage = messageBuilder.getDefaultIsNotVisibleMessage(htmlElement)
 ) {
-  waiters.waitForElementVisibility(htmlElement, timeoutInMilliseconds, errorMessage);
-  htmlElement.sendKeys(text);
+  utils.replaceObsoleteFunction("fillFieldWithTextWhenVisible", "fillFieldWithText");
+  this.fillFieldWithText(htmlElement, text, timeoutInMilliseconds);
 };
 
 const fillFieldWithText = function(
@@ -31,8 +31,8 @@ const fillInputFieldWithFileWhenPresent = function(
   timeoutInMilliseconds = utils.timeout.timeoutInMilliseconds,
   errorMessage = messageBuilder.getDefaultIsNotPresentMessage(htmlElement)
 ) {
-  waiters.waitForElementPresence(htmlElement, timeoutInMilliseconds, errorMessage);
-  htmlElement.sendKeys(absolutePath);
+  utils.replaceObsoleteFunction("fillInputFieldWithFileWhenPresent", "uploadFileIntoInputField");
+  this.uploadFileIntoInputField(htmlElement, absolutePath, timeoutInMilliseconds);
 };
 
 const uploadFileIntoInputField = function(
@@ -51,8 +51,8 @@ const clearFieldWhenVisible = function(
   timeoutInMilliseconds = utils.timeout.timeoutInMilliseconds,
   errorMessage = messageBuilder.getDefaultIsNotVisibleMessage(htmlElement)
 ) {
-  waiters.waitForElementVisibility(htmlElement, timeoutInMilliseconds, errorMessage);
-  htmlElement.clear();
+  utils.replaceObsoleteFunction("clearFieldWhenVisible", "clear");
+  this.clear(htmlElement, timeoutInMilliseconds);
 };
 
 const clear = function(
@@ -73,8 +73,8 @@ const clearFieldWhenVisibleAndFillItWithText = function(
   timeoutInMilliseconds = utils.timeout.timeoutInMilliseconds,
   errorMessage = messageBuilder.getDefaultIsNotVisibleMessage(htmlElement)
 ) {
-  this.clearFieldWhenVisible(htmlElement, timeoutInMilliseconds, errorMessage);
-  this.fillFieldWithTextWhenVisible(htmlElement, text, timeoutInMilliseconds, errorMessage);
+  utils.replaceObsoleteFunction("clearFieldWhenVisibleAndFillItWithText", "clearFieldAndFillItWithText");
+  this.clearFieldAndFillItWithText(htmlElement, text, timeoutInMilliseconds);
 };
 
 const clearFieldAndFillItWithText = function(
@@ -92,7 +92,8 @@ const fillFieldWithTextWhenVisibleAndPressEnter = function(
   timeoutInMilliseconds = utils.timeout.timeoutInMilliseconds,
   errorMessage = messageBuilder.getDefaultIsNotVisibleMessage(htmlElement)
 ) {
-  this.fillFieldWithTextWhenVisible(htmlElement, text + protractor.Key.ENTER, timeoutInMilliseconds, errorMessage);
+  utils.replaceObsoleteFunction("fillFieldWithTextWhenVisibleAndPressEnter", "fillFieldWithTextAndPressEnter");
+  this.fillFieldWithTextAndPressEnter(htmlElement, text, timeoutInMilliseconds);
 };
 
 const fillFieldWithTextAndPressEnter = function(

--- a/src/misc.js
+++ b/src/misc.js
@@ -6,6 +6,7 @@ const waiters = require("./waiters");
 const getBodyElementFromCurrentBrowserOrBrowserInstance = function(browserInstance) {
   const cssSelector = "body";
 
+  utils.obsoleteFunction("getBodyElementFromCurrentBrowserOrBrowserInstance");
   if (browserInstance) {
     return browserInstance.element(by.css(cssSelector));
   } else {
@@ -14,6 +15,7 @@ const getBodyElementFromCurrentBrowserOrBrowserInstance = function(browserInstan
 };
 
 const openNewBrowserInTheSamePage = function(browser = requiredParam(openNewBrowserInTheSamePage, "browser")) {
+  utils.obsoleteFunction("openNewBrowserInTheSamePage");
   return browser.forkNewDriverInstance(true);
 };
 
@@ -28,8 +30,8 @@ const scrollToElementWhenVisible = function(
   timeoutInMilliseconds = utils.timeout.timeoutInMilliseconds,
   errorMessage = messageBuilder.getDefaultIsNotVisibleMessage(htmlElement)
 ) {
-  waiters.waitForElementVisibility(htmlElement, timeoutInMilliseconds, errorMessage);
-  browser.executeScript("arguments[0].scrollIntoView(true);", htmlElement);
+  utils.replaceObsoleteFunction("scrollToElementWhenVisible", "scrollToElement");
+  this.scrollToElement(htmlElement, timeoutInMilliseconds);
 };
 
 const scrollToElement = function(


### PR DESCRIPTION
 I added deprecation warn on 10 functions. 2 will be removed and 8 replaced on version 4.0.0.
 To see the result on console clone the branch include-deprecated-warn and run the tests.
 The deprecation warn inform about the function that will replace him and have a link to the documentation about the deprecation.
 Read the README too, and tell me if it's ok or not.

 That PR resolve the issues #41, #32 and #24, and substitute the PR #37.

## Pull Request Checklist
	
	- [x] Have you followed the steps in our [Contributing](https://github.com/wlsf82/protractor-helper/blob/master/docs/CONTRIBUTING.md) document?
	- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wlsf82/protractor-helper/pulls) for the same update/change?
	- [x] Have you successfully ran tests with your changes locally?
	- [ ] Have you written new tests for your changes, if necessary?
	- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
	- [x] Have you made improvements to the documentation, if necessary? ([docs/](https://github.com/wlsf82/protractor-helper/tree/master/docs) folder and [README.md](https://github.com/wlsf82/protractor-helper/blob/master/README.md))
	- [x] Have you linked the correct [GitHub issue](https://github.com/wlsf82/protractor-helper/issues), if there is any?
	
	> Pull requests that do not pass the automated tests on [SemaphoreCI](http://semaphoreci.com) and the code quality verification on [Better Code Hub](https://bettercodehub.com/) will not be reviewed
