### PR TITLE
Create hoverAndClick function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.8.0
+
+- Implement `hoverAndClick` function and document it
+
 # 3.7.12
 
 - Update package-lock due to new version of selenium and related libraries, such as chromedriver

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Many of the helper functions on this library uses `protractor.ExpectedConditions
   - [`waitForElementNotToBeVisible`](#waitforelementnottobevisible)
   - [`clickWhenClickable`](#clickwhenclickable) **- Will be deprecated in version 4.0.0**
   - [`click`](#click)
+  - [`hoverAndClick`](#hoverAndClick)
   - [`fillFieldWithTextWhenVisible`](#fillfieldwithtextwhenvisible) **- Will be deprecated in version 4.0.0**
   - [`fillFieldWithText`](#fillfieldwithtext)
   - [`fillInputFieldWithFileWhenPresent`](#fillinputfieldwithfilewhenpresent) **- Will be deprecated in version 4.0.0**
@@ -216,6 +217,11 @@ This method is used to click in an element as soon as it is in a clickable state
 
 This method is used to click in an element as soon as it is in a clickable state. This means that the element is visible and enabled for clicking.
 [Example](docs/EXAMPLES.md#click)
+
+### `hoverAndClick`
+
+This method is used to hover over an element as soon as it is present in the DOM, and then click on it.
+[Example](docs/EXAMPLES.md#hoverAndClick)
 
 ### `fillFieldWithTextWhenVisible`
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -254,6 +254,28 @@ describe("foo", () => {
 });
 ```
 
+## hoverAndClick
+
+| 1 mandatory argument |   1 optional argument   |
+| :------------------: | :---------------------: |
+|    `htmlElement`     | `timeoutInMilliseconds` |
+
+```js
+const protractorHelper = require("protractor-helper");
+
+describe("foo", () => {
+  it("bar", () => {
+    browser.get("https://example.com");
+
+    const myButton = element(by.css("button.my-btn"));
+
+    protractorHelper.hoverAndClick(myButton, 3000);
+
+    // ...
+  });
+});
+```
+
 ## fillFieldWithTextWhenVisible
 
 > Note: This function will be deprecated in version 4.0.0 in favor of the function [`fillFieldWithText`](#fillFieldWithText).

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   clickWhenClickable: require("./src/clickersAndTappers").clickWhenClickable,
   click: require("./src/clickersAndTappers").click,
+  hoverAndClick: require("./src/clickersAndTappers").hoverAndClick,
   tapWhenTappable: require("./src/clickersAndTappers").tapWhenTappable,
   tap: require("./src/clickersAndTappers").tap,
   fillFieldWithTextWhenVisible: require("./src/inputFieldInteractions").fillFieldWithTextWhenVisible,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-helper",
-  "version": "3.7.12",
+  "version": "3.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-helper",
-  "version": "3.7.12",
+  "version": "3.8.0",
   "scripts": {
     "pretest": "webdriver-manager update --gecko false",
     "test": "jasmine test/spec/*.spec.js && protractor test/e2e/protractor.conf.js",

--- a/src/clickersAndTappers.js
+++ b/src/clickersAndTappers.js
@@ -1,6 +1,7 @@
 const deprecation = require("./constants_and_utils/deprecation");
 const messageBuilder = require("./constants_and_utils/messageBuilder");
 const utils = require("./constants_and_utils/utils");
+const waiters = require("./waiters");
 
 const clickWhenClickable = function(
   htmlElement = utils.requiredParam(clickWhenClickable),
@@ -20,6 +21,18 @@ const click = function(
     messageBuilder.getDefaultIsNotClickableMessage(htmlElement)
   );
   htmlElement.click();
+};
+
+const hoverAndClick = function(
+  htmlElement = utils.requiredParam(hoverAndClick),
+  timeoutInMilliseconds = utils.timeout.timeoutInMilliseconds
+) {
+  waiters.waitForElementPresence(htmlElement, timeoutInMilliseconds);
+  browser
+    .actions()
+    .mouseMove(htmlElement)
+    .click()
+    .perform();
 };
 
 const tapWhenTappable = function(
@@ -45,6 +58,7 @@ const tap = function(
 module.exports = {
   clickWhenClickable,
   click,
+  hoverAndClick,
   tapWhenTappable,
   tap
 };

--- a/test/e2e/sample.spec.js
+++ b/test/e2e/sample.spec.js
@@ -115,6 +115,10 @@ describe("Protractor helper", () => {
     it("fillFieldWithTextAndPressEnter", () => {
       helper.fillFieldWithTextAndPressEnter(inputField, constants.SAMPLE_URL);
     });
+
+    it("hoverAndClick", () => {
+      helper.hoverAndClick(expandButton);
+    });
   });
 
   describe("Misc", () => {


### PR DESCRIPTION
Adds a `hoverAndClick` function since some elements may only be in a clickable state after hovering over it.

## Pull Request Checklist

    - [x] Have you followed the steps in our [Contributing](https://github.com/wlsf82/protractor-helper/blob/master/docs/CONTRIBUTING.md) document?
    - [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wlsf82/protractor-helper/pulls) for the same update/change?
    - [x] Have you successfully ran tests with your changes locally?
    - [x] Have you written new tests for your changes, if necessary?
    - [x] Have you added an explanation of what your changes do and why you'd like us to include them?
    - [x] Have you made improvements to the documentation, if necessary? ([docs/](https://github.com/wlsf82/protractor-helper/tree/master/docs) folder and [README.md](https://github.com/wlsf82/protractor-helper/blob/master/README.md))
    - [-] Have you linked the correct [GitHub issue](https://github.com/wlsf82/protractor-helper/issues), if there is any?

    > Pull requests that do not pass the automated tests on [SemaphoreCI](http://semaphoreci.com) and the code quality verification on [Better Code Hub](https://bettercodehub.com/) will not be reviewed
