### PR TITLE
Increase code coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.4
+
+- Increase code coverage
+
 # 4.0.3
 
 - Update contributing docs and fix changelog typo

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -38,42 +38,40 @@ If all tests have passed you should see a result like this:
 ```sh
 $ npm t
 
-> protractor-helper@4.0.2 pretest /Users/walmyr/www/protractor-helper
+> protractor-helper@4.0.4 pretest /Users/walmyr/www/protractor-helper
 > webdriver-manager update --gecko false
 
-[02:06:18] I/config_source - curl -o/Users/walmyr/www/protractor-helper/node_modules/protractor/node_modules/webdriver-manager/selenium/standalone-response.xml https://selenium-release.storage.googleapis.com/
-[02:06:18] I/config_source - curl -o/Users/walmyr/www/protractor-helper/node_modules/protractor/node_modules/webdriver-manager/selenium/chrome-response.xml https://chromedriver.storage.googleapis.com/
-[02:06:19] I/update - selenium standalone: file exists /Users/walmyr/www/protractor-helper/node_modules/protractor/node_modules/webdriver-manager/selenium/selenium-server-standalone-3.141.59.jar
-[02:06:19] I/update - selenium standalone: selenium-server-standalone-3.141.59.jar up to date
-[02:06:19] I/update - chromedriver: file exists /Users/walmyr/www/protractor-helper/node_modules/protractor/node_modules/webdriver-manager/selenium/chromedriver_77.0.3865.40.zip
-[02:06:19] I/update - chromedriver: unzipping chromedriver_77.0.3865.40.zip
-[02:06:19] I/update - chromedriver: setting permissions to 0755 for /Users/walmyr/www/protractor-helper/node_modules/protractor/node_modules/webdriver-manager/selenium/chromedriver_77.0.3865.40
-[02:06:19] I/update - chromedriver: chromedriver_77.0.3865.40 up to date
+[02:28:41] I/update - chromedriver: file exists /Users/walmyr/www/protractor-helper/node_modules/protractor/node_modules/webdriver-manager/selenium/chromedriver_77.0.3865.40.zip
+[02:28:41] I/update - chromedriver: unzipping chromedriver_77.0.3865.40.zip
+[02:28:41] I/update - chromedriver: setting permissions to 0755 for /Users/walmyr/www/protractor-helper/node_modules/protractor/node_modules/webdriver-manager/selenium/chromedriver_77.0.3865.40
+[02:28:41] I/update - chromedriver: chromedriver_77.0.3865.40 up to date
+[02:28:41] I/update - selenium standalone: file exists /Users/walmyr/www/protractor-helper/node_modules/protractor/node_modules/webdriver-manager/selenium/selenium-server-standalone-3.141.59.jar
+[02:28:41] I/update - selenium standalone: selenium-server-standalone-3.141.59.jar up to date
 
-> protractor-helper@4.0.2 test /Users/walmyr/www/protractor-helper
+> protractor-helper@4.0.4 test /Users/walmyr/www/protractor-helper
 > jasmine test/spec/*.spec.js && protractor test/e2e/protractor.conf.js
 
-Randomized with seed 36096
+Randomized with seed 67067
 Started
 ..............
 
 
 14 specs, 0 failures
 Finished in 0.017 seconds
-Randomized with seed 36096 (jasmine --random=true --seed=36096)
-[02:06:20] I/launcher - Running 1 instances of WebDriver
-[02:06:20] I/direct - Using ChromeDriver directly...
-Randomized with seed 33447
+Randomized with seed 67067 (jasmine --random=true --seed=67067)
+[02:28:41] I/launcher - Running 1 instances of WebDriver
+[02:28:41] I/direct - Using ChromeDriver directly...
+Randomized with seed 09749
 Started
-.....................
+........................................
 
 
-21 specs, 0 failures
-Finished in 2.348 seconds
+40 specs, 0 failures
+Finished in 3.681 seconds
 
-Randomized with seed 33447
-[02:06:23] I/launcher - 0 instance(s) of WebDriver still running
-[02:06:23] I/launcher - chrome #01 passed
+Randomized with seed 09749
+[02:28:45] I/launcher - 0 instance(s) of WebDriver still running
+[02:28:45] I/launcher - chrome #01 passed
 ```
 
 [Back to section 'Contributing' on README.md](../README.md#contributing)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-helper",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-helper",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "scripts": {
     "pretest": "webdriver-manager update --gecko false",
     "test": "jasmine test/spec/*.spec.js && protractor test/e2e/protractor.conf.js",

--- a/test/e2e/sample.spec.js
+++ b/test/e2e/sample.spec.js
@@ -11,6 +11,8 @@ describe("Protractor helper", () => {
 
   const nonExistingElement = element(by.id("foo"));
 
+  const ONE_SEC_IN_MS = 1000;
+
   beforeEach(() => browser.get(""));
 
   describe("waits", () => {
@@ -18,40 +20,80 @@ describe("Protractor helper", () => {
       helper.waitForElementNotToBePresent(nonExistingElement);
     });
 
+    it("waitForElementNotToBePresent with different timeout", () => {
+      helper.waitForElementNotToBePresent(nonExistingElement, ONE_SEC_IN_MS);
+    });
+
     it("waitForElementNotToBeVisible", () => {
       helper.waitForElementNotToBeVisible(nonExistingElement);
+    });
+
+    it("waitForElementNotToBeVisible with different timeout", () => {
+      helper.waitForElementNotToBeVisible(nonExistingElement, ONE_SEC_IN_MS);
     });
 
     it("waitForTextNotToBePresentInElement", () => {
       helper.waitForTextNotToBePresentInElement(titleElement, constants.TEXT_NOT_EXISTING_ON_VISIBLE_ELEMENTS);
     });
 
+    it("waitForTextNotToBePresentInElement with different timeout", () => {
+      helper.waitForTextNotToBePresentInElement(titleElement, constants.TEXT_NOT_EXISTING_ON_VISIBLE_ELEMENTS, ONE_SEC_IN_MS);
+    });
+
     it("waitForUrlToBeEqualToExpectedUrl", () => {
       helper.waitForUrlToBeEqualToExpectedUrl(constants.BASE_URL);
+    });
+
+    it("waitForUrlToBeEqualToExpectedUrl with different timeout", () => {
+      helper.waitForUrlToBeEqualToExpectedUrl(constants.BASE_URL, ONE_SEC_IN_MS);
     });
 
     it("waitForUrlNotToBeEqualToExpectedUrl", () => {
       helper.waitForUrlNotToBeEqualToExpectedUrl(constants.SAMPLE_URL);
     });
 
+    it("waitForUrlNotToBeEqualToExpectedUrl with different timeout", () => {
+      helper.waitForUrlNotToBeEqualToExpectedUrl(constants.SAMPLE_URL, ONE_SEC_IN_MS);
+    });
+
     it("waitForUrlToContainString", () => {
       helper.waitForUrlToContainString(constants.INDEX_DOT_HTML_STRING);
+    });
+
+    it("waitForUrlToContainString with different timeout", () => {
+      helper.waitForUrlToContainString(constants.INDEX_DOT_HTML_STRING, ONE_SEC_IN_MS);
     });
 
     it("waitForUrlNotToContainString", () => {
       helper.waitForUrlNotToContainString(constants.SAMPLE_URL);
     });
 
+    it("waitForUrlNotToContainString with different timeout", () => {
+      helper.waitForUrlNotToContainString(constants.SAMPLE_URL, ONE_SEC_IN_MS);
+    });
+
     it("waitForElementVisibility", () => {
       helper.waitForElementVisibility(inputField);
+    });
+
+    it("waitForElementVisibility with different timeout", () => {
+      helper.waitForElementVisibility(inputField, ONE_SEC_IN_MS);
     });
 
     it("waitForElementPresence", () => {
       helper.waitForElementPresence(inputField);
     });
 
+    it("waitForElementPresence with different timeout", () => {
+      helper.waitForElementPresence(inputField, ONE_SEC_IN_MS);
+    });
+
     it("waitForTextToBePresentInElement", () => {
       helper.waitForTextToBePresentInElement(titleElement, constants.TITLE_TEXT);
+    });
+
+    it("waitForTextToBePresentInElement with different timeout", () => {
+      helper.waitForTextToBePresentInElement(titleElement, constants.TITLE_TEXT, ONE_SEC_IN_MS);
     });
   });
 
@@ -60,12 +102,24 @@ describe("Protractor helper", () => {
       helper.fillFieldWithText(inputField, constants.SHORTEN_URL);
     });
 
+    it("fillFieldWithText with different timeout", () => {
+      helper.fillFieldWithText(inputField, constants.SHORTEN_URL, ONE_SEC_IN_MS);
+    });
+
     it("click", () => {
       helper.click(shortenButton);
     });
 
+    it("click with different timeout", () => {
+      helper.click(shortenButton, ONE_SEC_IN_MS);
+    });
+
     it("uploadFileIntoInputField", () => {
       helper.uploadFileIntoInputField(inputFile, constants.ABSOLUTE_PATH_OF_INDEX_FILE);
+    });
+
+    it("uploadFileIntoInputField with different timeout", () => {
+      helper.uploadFileIntoInputField(inputFile, constants.ABSOLUTE_PATH_OF_INDEX_FILE, ONE_SEC_IN_MS);
     });
 
     it("clear", () => {
@@ -73,21 +127,43 @@ describe("Protractor helper", () => {
       helper.clear(inputField);
     });
 
+    it("clear with different timeout", () => {
+      helper.fillFieldWithText(inputField, constants.SHORTEN_URL);
+      helper.clear(inputField, ONE_SEC_IN_MS);
+    });
+
     it("clearFieldAndFillItWithText", () => {
       helper.fillFieldWithText(inputField, constants.SHORTEN_URL);
       helper.clearFieldAndFillItWithText(inputField, constants.SAMPLE_URL);
+    });
+
+    it("clearFieldAndFillItWithText with different timeout", () => {
+      helper.fillFieldWithText(inputField, constants.SHORTEN_URL);
+      helper.clearFieldAndFillItWithText(inputField, constants.SAMPLE_URL, ONE_SEC_IN_MS);
     });
 
     it("tap", () => {
       helper.tap(expandButton);
     });
 
+    it("tap with different timeout", () => {
+      helper.tap(expandButton, ONE_SEC_IN_MS);
+    });
+
     it("fillFieldWithTextAndPressEnter", () => {
       helper.fillFieldWithTextAndPressEnter(inputField, constants.SAMPLE_URL);
     });
 
+    it("fillFieldWithTextAndPressEnter with different timeout", () => {
+      helper.fillFieldWithTextAndPressEnter(inputField, constants.SAMPLE_URL, ONE_SEC_IN_MS);
+    });
+
     it("hoverAndClick", () => {
       helper.hoverAndClick(expandButton);
+    });
+
+    it("hoverAndClick with different timeout", () => {
+      helper.hoverAndClick(expandButton, ONE_SEC_IN_MS);
     });
   });
 
@@ -98,6 +174,10 @@ describe("Protractor helper", () => {
 
     it("scrollToElement", () => {
       helper.scrollToElement(shortenButton);
+    });
+
+    it("scrollToElement with different timeout", () => {
+      helper.scrollToElement(shortenButton, ONE_SEC_IN_MS);
     });
 
     it("setTimeout", () => {


### PR DESCRIPTION
Increase code coverage by testing the call of all functions that accept a timeout arg with and without it.

This way, we ensure that the functions work with the default timeout, but also if a different one is provided.

## Pull Request Checklist

    - [x] Have you followed the steps in our [Contributing](https://github.com/wlsf82/protractor-helper/blob/master/docs/CONTRIBUTING.md) document?
    - [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wlsf82/protractor-helper/pulls) for the same update/change?
    - [x] Have you successfully ran tests with your changes locally?
    - [x] Have you written new tests for your changes, if necessary?
    - [x] Have you added an explanation of what your changes do and why you'd like us to include them?
    - [x] Have you made improvements to the documentation, if necessary? ([docs/](https://github.com/wlsf82/protractor-helper/tree/master/docs) folder and [README.md](https://github.com/wlsf82/protractor-helper/blob/master/README.md))
    - [-] Have you linked the correct [GitHub issue](https://github.com/wlsf82/protractor-helper/issues), if there is any?

    > Pull requests that do not pass the automated tests on [SemaphoreCI](http://semaphoreci.com) and the code quality verification on [Better Code Hub](https://bettercodehub.com/) will not be reviewed
