### PR TITLE
Remove unnecessary keyword `this` from functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.5
+
+- Remove unnecessary keyword this from functions
+
 # 4.0.4
 
 - Increase code coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-helper",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-helper",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "scripts": {
     "pretest": "webdriver-manager update --gecko false",
     "test": "jasmine test/spec/*.spec.js && protractor test/e2e/protractor.conf.js",

--- a/src/inputFieldInteractions.js
+++ b/src/inputFieldInteractions.js
@@ -43,8 +43,8 @@ const clearFieldAndFillItWithText = function(
   text = utils.requiredParam(clearFieldAndFillItWithText, "text"),
   timeoutInMilliseconds = utils.timeout.timeoutInMilliseconds
 ) {
-  this.clear(htmlElement, timeoutInMilliseconds);
-  this.fillFieldWithText(htmlElement, text, timeoutInMilliseconds);
+  clear(htmlElement, timeoutInMilliseconds);
+  fillFieldWithText(htmlElement, text, timeoutInMilliseconds);
 };
 
 const fillFieldWithTextAndPressEnter = function(
@@ -52,7 +52,7 @@ const fillFieldWithTextAndPressEnter = function(
   text = utils.requiredParam(fillFieldWithTextAndPressEnter, "text"),
   timeoutInMilliseconds = utils.timeout.timeoutInMilliseconds
 ) {
-  this.fillFieldWithText(htmlElement, text + protractor.Key.ENTER, timeoutInMilliseconds);
+  fillFieldWithText(htmlElement, text + protractor.Key.ENTER, timeoutInMilliseconds);
 };
 
 module.exports = {


### PR DESCRIPTION
Also, update the changelog and package patch version.

## Pull Request Checklist

    - [x] Have you followed the steps in our [Contributing](https://github.com/wlsf82/protractor-helper/blob/master/docs/CONTRIBUTING.md) document?
    - [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wlsf82/protractor-helper/pulls) for the same update/change?
    - [x] Have you successfully ran tests with your changes locally?
    - [-] Have you written new tests for your changes, if necessary?
    - [x] Have you added an explanation of what your changes do and why you'd like us to include them?
    - [-] Have you made improvements to the documentation, if necessary? ([docs/](https://github.com/wlsf82/protractor-helper/tree/master/docs) folder and [README.md](https://github.com/wlsf82/protractor-helper/blob/master/README.md))
    - [-] Have you linked the correct [GitHub issue](https://github.com/wlsf82/protractor-helper/issues), if there is any?

    > Pull requests that do not pass the automated tests on [SemaphoreCI](http://semaphoreci.com) and the code quality verification on [Better Code Hub](https://bettercodehub.com/) will not be reviewed
