### PR TITLE
Extract message to message builder, uses it on utils, and test it out

### DIFF
--- a/src/constants_and_utils/messageBuilder.js
+++ b/src/constants_and_utils/messageBuilder.js
@@ -64,6 +64,12 @@ function getDefaultTextTextNotPresentOnElementMessage(htmlElement, text) {
   }'.`;
 }
 
+function getParameterIsMissingForFunctionMessage(param, fn) {
+  return `Parameter '${param}' is missing at function '${
+    fn.name
+  }()'. \nFill the required parameter.`;
+}
+
 module.exports = {
   getDefaultCurrentUrlContainsTheString,
   getDefaultCurrentUrlDoesNotContainStringMessage,
@@ -76,5 +82,6 @@ module.exports = {
   getDefaultIsNotTappableMessage,
   getDefaultIsStillVisibleMessage,
   getDeafultTextTextIsStillPresentOnElementMessage,
-  getDefaultTextTextNotPresentOnElementMessage
+  getDefaultTextTextNotPresentOnElementMessage,
+  getParameterIsMissingForFunctionMessage
 };

--- a/src/constants_and_utils/utils.js
+++ b/src/constants_and_utils/utils.js
@@ -1,5 +1,7 @@
 const protractor = require("protractor");
 
+const messageBuilder = require("./messageBuilder");
+
 const timeoutInMilliseconds = require("./constants").DEFAULT_TIMEOUT_IN_MS;
 
 const EC = protractor.ExpectedConditions;
@@ -7,9 +9,7 @@ const timeout = { timeoutInMilliseconds };
 
 function requiredParam(functionWithoutParam, requiredParameter = "htmlElement") {
   const requiredParamError = new Error(
-    `Parameter '${requiredParameter}' is missing at function '${
-      functionWithoutParam.name
-    }()'. \nFill the required parameter.`
+    messageBuilder.getParameterIsMissingForFunctionMessage(requiredParameter, functionWithoutParam)
   );
   Error.captureStackTrace(requiredParamError, functionWithoutParam);
   throw requiredParamError;

--- a/test/spec/messageBuilder.spec.js
+++ b/test/spec/messageBuilder.spec.js
@@ -172,4 +172,16 @@ describe("messageBuilder", () => {
 
     expect(actualResult).toEqual(expectedResult);
   });
+
+  it("getParameterIsMissingForFunctionMessage", () => {
+    const sampleParam = "text";
+    const fn = { name: "sampleFunction" };
+
+    const actualResult = messageBuilder.getParameterIsMissingForFunctionMessage(sampleParam, fn);
+    const expectedResult = `Parameter '${sampleParam}' is missing at function '${
+      fn.name
+    }()'. \nFill the required parameter.`;
+
+    expect(actualResult).toEqual(expectedResult);
+  });
 });


### PR DESCRIPTION
## Pull Request Checklist

This PR moves some message related logic that was inside utils to the message builder module since dealing with messages is its responsibility.

- [x] Have you followed the steps in our [Contributing](https://github.com/wlsf82/protractor-helper/blob/master/docs/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wlsf82/protractor-helper/pulls) for the same update/change?
- [x] Have you successfully ran tests with your changes locally?
- [x] Have you written new tests for your changes, if necessary?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [-] Have you made improvements to the documentation, if necessary? ([docs/](https://github.com/wlsf82/protractor-helper/tree/master/docs) folder and [README.md](https://github.com/wlsf82/protractor-helper/blob/master/README.md))
- [-] Have you linked the correct [GitHub issue](https://github.com/wlsf82/protractor-helper/issues), if there is any?

> Pull requests that do not pass the coding static analysis and the automated tests on [Github Actions](https://github.com/wlsf82/protractor-helper/actions), and the code quality verification on [Better Code Hub](https://bettercodehub.com/) will not be reviewed.
